### PR TITLE
Fix apidoc deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ jobs:
         skip-cleanup: true
         github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
         keep-history: true
-        local-dir: doc # We already cd into the backend dir
+        local-dir: backend/doc
         on:
           branch: master


### PR DESCRIPTION
In this PR https://github.com/travis-ci/dpl/pull/740, Travis fixed the side-effect where having a build script that cd into a directory would change the working dir for the deployment (More information here https://github.com/travis-ci/travis-ci/issues/9047#issuecomment-359118446)